### PR TITLE
new argument bfe-reload-address

### DIFF
--- a/cmd/ingress-controller/flags.go
+++ b/cmd/ingress-controller/flags.go
@@ -28,6 +28,7 @@ var (
 	namespaces     string
 	ingressClass   string
 	configPath     string
+	reloadAddr     string
 	metricsAddr    string
 	probeAddr      string
 	defaultBackend string
@@ -46,6 +47,7 @@ func initFlags() {
 	flag.StringVar(&configPath, "bfe-config-path", option.ConfigPath, "Root directory of bfe configuration files.")
 	flag.StringVar(&configPath, "c", option.ConfigPath, "Root directory of bfe configuration files.")
 
+	flag.StringVar(&reloadAddr, "bfe-reload-address", option.ReloadAddr, "Address of bfe config reloading.")
 	flag.StringVar(&ingressClass, "ingress-class", option.IngressClassName, "Class name of bfe ingress controller.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", option.MetricsBindAddress, "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", option.HealthProbeBindAddress, "The address the probe endpoint binds to.")

--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	err := option.SetOptions(
-		namespaces, ingressClass, configPath,
+		namespaces, ingressClass, configPath, reloadAddr,
 		metricsAddr, probeAddr, defaultBackend)
 	if err != nil {
 		setupLog.Error(err, "fail to start controllers")

--- a/internal/option/options.go
+++ b/internal/option/options.go
@@ -25,8 +25,9 @@ import (
 
 const (
 	ConfigPath      = "/bfe/conf/"
-	reloadUrlPrefix = "http://localhost:8421/reload/"
+	ReloadAddr      = "localhost:8421"
 	reloadInterval  = 3 * time.Second
+	reloadUrlPrefix = "http://%s/reload/"
 
 	FilePerm os.FileMode = 0744
 
@@ -59,9 +60,7 @@ var (
 	Opts *Options
 )
 
-func SetOptions(namespaces, class, configPath, metricsAddr, probeAddr, defaultBackend string) error {
-	ns := strings.Split(namespaces, ",")
-
+func SetOptions(namespaces, class, configPath, reloadAddr, metricsAddr, probeAddr, defaultBackend string) error {
 	if len(defaultBackend) > 0 {
 		names := strings.Split(defaultBackend, string(types.Separator))
 		if len(names) != 2 {
@@ -69,11 +68,15 @@ func SetOptions(namespaces, class, configPath, metricsAddr, probeAddr, defaultBa
 		}
 	}
 
+	if !strings.HasSuffix(configPath, "/") {
+		configPath = configPath + "/"
+	}
+
 	Opts = &Options{
-		Namespaces:      ns,
+		Namespaces:      strings.Split(namespaces, ","),
 		IngressClass:    class,
 		ControllerName:  ControllerName,
-		ReloadUrl:       reloadUrlPrefix,
+		ReloadUrl:       fmt.Sprintf(reloadUrlPrefix, reloadAddr),
 		ConfigPath:      configPath,
 		MetricsAddr:     metricsAddr,
 		HealthProbeAddr: probeAddr,
@@ -81,8 +84,5 @@ func SetOptions(namespaces, class, configPath, metricsAddr, probeAddr, defaultBa
 		DefaultBackend:  defaultBackend,
 	}
 
-	if !strings.HasSuffix(configPath, "/") {
-		Opts.ConfigPath = Opts.ConfigPath + "/"
-	}
 	return nil
 }


### PR DESCRIPTION
add new command line argument for controller bfe-reload-address, which set the address for reloading bfe config. The default value is localhost:8421, same as monitor port in bfe.conf.
