### PR TITLE
BugFix: config files will not be updated when remove bfe annotations from an existing ingress

### DIFF
--- a/internal/bfeConfig/configs/cache/baseCache.go
+++ b/internal/bfeConfig/configs/cache/baseCache.go
@@ -107,6 +107,7 @@ func (c *BaseCache) GetRules() []Rule {
 // DeleteByIngress deletes the Rules of an Ingress from the cache
 func (c *BaseCache) DeleteByIngress(ingress string) {
 	c.BaseRules.delete(ingress)
+	c.Version = util.NewVersion()
 }
 
 // ContainsIngress returns true if ingress exist in cache

--- a/internal/bfeConfig/configs/modules/redirect/cache.go
+++ b/internal/bfeConfig/configs/modules/redirect/cache.go
@@ -42,6 +42,10 @@ func newRedirectRuleCache(version string) *redirectRuleCache {
 }
 
 func (c redirectRuleCache) UpdateByIngress(ingress *netv1.Ingress) error {
+	if len(ingress.Spec.Rules) == 0 {
+		return nil
+	}
+
 	cmd, param, err := parseRedirectActionFromAnnotations(ingress.Annotations)
 	if err != nil {
 		return err

--- a/internal/bfeConfig/configs/modules/redirect/redirect.go
+++ b/internal/bfeConfig/configs/modules/redirect/redirect.go
@@ -57,10 +57,6 @@ func newRedirectConfFile(version string) *mod_redirect.RedirectConfFile {
 }
 
 func (r *ModRedirectConfig) UpdateIngress(ingress *netv1.Ingress) error {
-	if len(ingress.Spec.Rules) == 0 {
-		return nil
-	}
-
 	ingressName := util.NamespacedName(ingress.Namespace, ingress.Name)
 	if r.redirectRuleCache.ContainsIngress(ingressName) {
 		r.redirectRuleCache.DeleteByIngress(ingressName)

--- a/test/e2e/features/annotations/redirect/redirect.feature
+++ b/test/e2e/features/annotations/redirect/redirect.feature
@@ -233,6 +233,56 @@ Feature: Redirect
     Then the response status-code must be 301
     And the response location must be "https://foo.com/bar"
 
+  Scenario: An Ingress with redirect annotations is applied and
+  then the ingress is updated by removing the redirect annotations.
+    Given an Ingress resource with redirection annotations
+    """
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: redirect-url-set
+      annotations:
+        bfe.ingress.kubernetes.io/redirect.url-set: "https://www.baidu.com"
+    spec:
+      rules:
+        - host: "foo.com"
+          http:
+            paths:
+              - path: /bar
+                pathType: Prefix
+                backend:
+                  service:
+                    name: foo-exact
+                    port:
+                      number: 3000
+    """
+    And The Ingress status shows the IP address or FQDN where it is exposed
+    When I send a "GET" request to "http://foo.com/bar"
+    Then the response status-code must be 302
+    And the response location must be "https://www.baidu.com"
+    Then update the ingress by removing the redirect annotations
+    """
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: redirect-url-set
+    spec:
+      rules:
+        - host: "foo.com"
+          http:
+            paths:
+              - path: /bar
+                pathType: Prefix
+                backend:
+                  service:
+                    name: foo-exact
+                    port:
+                      number: 3000
+    """
+    And The Ingress status shows the IP address or FQDN where it is exposed
+    When I send a "GET" request to "http://foo.com/bar"
+    Then the response status-code must be 200
+
 
   Scenario: An Ingress with annotation `bfe.ingress.kubernetes.io/redirect.url-set` whose value
   is invalid

--- a/test/e2e/features/annotations/redirect/redirect.feature
+++ b/test/e2e/features/annotations/redirect/redirect.feature
@@ -260,7 +260,7 @@ Feature: Redirect
     When I send a "GET" request to "http://foo.com/bar"
     Then the response status-code must be 302
     And the response location must be "https://www.baidu.com"
-    Then update the ingress by removing the redirect annotations
+    Then update the ingress
     """
     apiVersion: networking.k8s.io/v1
     kind: Ingress
@@ -278,6 +278,50 @@ Feature: Redirect
                     name: foo-exact
                     port:
                       number: 3000
+    """
+    And The Ingress status shows the IP address or FQDN where it is exposed
+    When I send a "GET" request to "http://foo.com/bar"
+    Then the response status-code must be 200
+
+  Scenario: An Ingress with redirect annotations is applied and
+  then the ingress is updated by removing the rules.
+    Given an Ingress resource with redirection annotations
+    """
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: redirect-url-set
+      annotations:
+        bfe.ingress.kubernetes.io/redirect.url-set: "https://www.baidu.com"
+    spec:
+      rules:
+        - host: "foo.com"
+          http:
+            paths:
+              - path: /bar
+                pathType: Prefix
+                backend:
+                  service:
+                    name: foo-exact
+                    port:
+                      number: 3000
+    """
+    And The Ingress status shows the IP address or FQDN where it is exposed
+    When I send a "GET" request to "http://foo.com/bar"
+    Then the response status-code must be 302
+    And the response location must be "https://www.baidu.com"
+    Then update the ingress
+    """
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: redirect-url-set
+    spec:
+      defaultBackend:
+        service:
+          name: foo-exact
+          port:
+            number: 3000
     """
     And The Ingress status shows the IP address or FQDN where it is exposed
     When I send a "GET" request to "http://foo.com/bar"

--- a/test/e2e/pkg/kubernetes/kubernetes.go
+++ b/test/e2e/pkg/kubernetes/kubernetes.go
@@ -205,6 +205,20 @@ func NewIngress(c kubernetes.Interface, namespace string, ingress *networking.In
 	return nil
 }
 
+// UpdateIngress updates an existing ingress
+func UpdateIngress(c kubernetes.Interface, namespace string, ingress *networking.Ingress) error {
+	err := displayYamlDefinition(ingress)
+	if err != nil {
+		return fmt.Errorf("unable show yaml definition: %v", err)
+	}
+
+	if _, err := c.NetworkingV1().Ingresses(namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // IngressFromSpec deserializes an Ingress definition using an IngressSpec
 func IngressFromSpec(name, namespace, ingressSpec string) (*networking.Ingress, error) {
 	if namespace == metav1.NamespaceNone || namespace == metav1.NamespaceDefault {

--- a/test/e2e/steps/annotations/redirect/steps.go
+++ b/test/e2e/steps/annotations/redirect/steps.go
@@ -35,7 +35,7 @@ var state *tstate.Scenario
 // InitializeScenario configures the Feature to test
 func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^an Ingress resource with redirection annotations$`, anIngressResourceWithRedirectionAnnotations)
-	ctx.Step(`^update the ingress by removing the redirect annotations$`, updateIngress)
+	ctx.Step(`^update the ingress$`, updateIngress)
 	ctx.Step(`^The Ingress status shows the IP address or FQDN where it is exposed$`, theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed)
 	ctx.Step(`^I send a "([^"]*)" request to "([^"]*)"$`, iSendARequestTo)
 	ctx.Step(`^the response status-code must be (\d+)$`, theResponseStatusCodeMustBe)

--- a/test/e2e/steps/annotations/redirect/steps.go
+++ b/test/e2e/steps/annotations/redirect/steps.go
@@ -16,6 +16,7 @@ package redirect
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -34,6 +35,7 @@ var state *tstate.Scenario
 // InitializeScenario configures the Feature to test
 func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^an Ingress resource with redirection annotations$`, anIngressResourceWithRedirectionAnnotations)
+	ctx.Step(`^update the ingress by removing the redirect annotations$`, updateIngress)
 	ctx.Step(`^The Ingress status shows the IP address or FQDN where it is exposed$`, theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed)
 	ctx.Step(`^I send a "([^"]*)" request to "([^"]*)"$`, iSendARequestTo)
 	ctx.Step(`^the response status-code must be (\d+)$`, theResponseStatusCodeMustBe)
@@ -76,6 +78,23 @@ func anIngressResourceWithRedirectionAnnotations(spec *godog.DocString) error {
 	}
 
 	state.IngressName = ingress.GetName()
+
+	return nil
+}
+
+func updateIngress(spec *godog.DocString) error {
+	ingress, err := kubernetes.IngressFromManifest(state.Namespace, spec.Content)
+	if err != nil {
+		return err
+	}
+	if ingress.GetName() != state.IngressName {
+		return errors.New("ingress name is not match with the ingressName stored in the state when try to update")
+	}
+
+	err = kubernetes.UpdateIngress(kubernetes.KubeClient, state.Namespace, ingress)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
By now, when delete bfe annotations from an existing ingress that already has bfe annotations, the ingress-bfe controller will not remove the rules from the config files.

And, when set the `spec.rules` of an existing ingress empty, the controller won't remove the rules from the redirect config files either.

This PR updates the `Version` of rule cache every time when `DeleteByIngress` is called and check whether the `spec.rules` is empty after deleting the ingress from rule cache (not before the delete action).

This PR also adds some e2e test scenarios to verify the patch.

Signed-off-by: loheagn <loheagn@icloud.com>